### PR TITLE
Fixed travis CI deploy pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ jobs:
       if: type NOT IN (pull_request)
       script:
         - echo "Deploying to Staging"
+
+      before_deploy:
+        - rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday -v 1.9.3
       deploy:
         provider: heroku
         app: switcher-api-staging


### PR DESCRIPTION
ERROR:  Error installing dpl-heroku:

The last version of faraday (>= 0) to support your Ruby & RubyGems was 1.9.3. Try installing it with `gem install faraday -v 1.9.3` and then running the current command again 
faraday requires Ruby version >= 2.6. The current ruby version is 2.4.5.335.