### PR TITLE
Fixes default rate limit to accept unlimited rate

### DIFF
--- a/src/middleware/limiter.js
+++ b/src/middleware/limiter.js
@@ -5,11 +5,20 @@ const ERROR_MESSAGE = {
 	error: 'API request per minute quota exceeded'
 };
 
+const getMaxRate = (rate_limit) => {
+	if (rate_limit === 0) {
+		return parseInt(DEFAULT_RATE_LIMIT);
+	}
+
+	return rate_limit;
+};
+
 export const DEFAULT_RATE_LIMIT = 1000;
 
 export const defaultLimiter = rateLimit({
 	windowMs: DEFAULT_WINDOWMS,
-	limit: parseInt(process.env.MAX_REQUEST_PER_MINUTE || DEFAULT_RATE_LIMIT),
+	limit: getMaxRate(parseInt(process.env.MAX_REQUEST_PER_MINUTE)),
+	skip: (request) => request.rate_limit === 0,
 	standardHeaders: 'draft-7',
 	legacyHeaders: false,
     message: ERROR_MESSAGE,

--- a/tests/unit-test/limiter/app-limiter-set.test.js
+++ b/tests/unit-test/limiter/app-limiter-set.test.js
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+import request from 'supertest';
+
+let app = null;
+
+afterAll(async () => { 
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  await mongoose.disconnect();
+});
+
+beforeAll(async () => {
+  process.env.MAX_REQUEST_PER_MINUTE = 1;
+  app = (await import('../../../src/app')).default;
+});
+
+describe('When maximum request per minute is postive', () => {
+  test('LIMITER_SUITE - Should return 429 - Too many requests', async () => {
+    await request(app)
+      .get('/check')
+      .expect(200);
+
+    const req = await request(app)
+      .get('/check')
+      .expect(429);
+
+    expect(req.statusCode).toBe(429);
+    expect(req.body.error).toEqual('API request per minute quota exceeded');
+  });
+});

--- a/tests/unit-test/limiter/app-limiter-set.test.js
+++ b/tests/unit-test/limiter/app-limiter-set.test.js
@@ -13,7 +13,7 @@ beforeAll(async () => {
   app = (await import('../../../src/app')).default;
 });
 
-describe('When maximum request per minute is postive', () => {
+describe('When maximum request per minute is positive', () => {
   test('LIMITER_SUITE - Should return 429 - Too many requests', async () => {
     await request(app)
       .get('/check')

--- a/tests/unit-test/limiter/app-limiter-unlimited.test.js
+++ b/tests/unit-test/limiter/app-limiter-unlimited.test.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+import request from 'supertest';
+
+let app = null;
+
+afterAll(async () => { 
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  await mongoose.disconnect();
+});
+
+beforeAll(async () => {
+  process.env.MAX_REQUEST_PER_MINUTE = 0;
+  app = (await import('../../../src/app')).default;
+});
+
+describe('When maximum request per minute is zero (unlimited)', () => {
+  test('LIMITER_SUITE - Should return 200 - OK', async () => {
+    await request(app)
+      .get('/check')
+      .expect(200);
+  });
+});


### PR DESCRIPTION
MAX_REQUEST_PER_MINUTE when set to 0 will allow unlimited API rate.