### PR TITLE
patch: NoSQL injection vulnerabilities introduced by GraphQL resolvers

### DIFF
--- a/src/aggregator/resolvers.js
+++ b/src/aggregator/resolvers.js
@@ -1,10 +1,11 @@
+import { Types } from 'mongoose';
 import { EnvType } from '../models/environment.js';
 import Domain from '../models/domain.js';
 import GroupConfig from '../models/group-config.js';
 import { Config } from '../models/config.js';
-import { ConfigStrategy } from '../models/config-strategy.js';
+import { ConfigStrategy, OperationsType, StrategiesType } from '../models/config-strategy.js';
 import { ActionTypes, RouterTypes } from '../models/permission.js';
-import { verifyOwnership } from '../helpers/index.js';
+import { formatInput, verifyOwnership } from '../helpers/index.js';
 import Component from '../models/component.js';
 import Logger from '../helpers/logger.js';
 
@@ -26,9 +27,9 @@ export function resolveEnvValue(source, field, keys) {
 export async function resolveConfigStrategy(source, _id, strategy, operation, activated, context) {
     const args = {};
 
-    if (_id) { args._id = _id; }
-    if (strategy) { args.strategy = strategy; }
-    if (operation) { args.operation = operation; }
+    if (_id) { args._id = new Types.ObjectId(_id); }
+    if (strategy) { args.strategy = Object.values(StrategiesType).find(t => t === strategy); }
+    if (operation) { args.operation = Object.values(OperationsType).find(t => t === operation); }
     
     let strategies = await ConfigStrategy.find({ config: source._id, ...args }).lean().exec();
     const environment = context.environment;
@@ -65,8 +66,8 @@ export async function resolveRelay(source, context) {
 export async function resolveConfig(source, _id, key, activated, context) {
     const args = {};
 
-    if (_id) { args._id = _id; }
-    if (key) { args.key = key; }
+    if (_id) { args._id = new Types.ObjectId(_id); }
+    if (key) { args.key = formatInput(key, { toUpper: true, autoUnderscore: true }); }
     if (context._component) { args.components = context._component; }
     
     let configs = await Config.find({ group: source._id, ...args }).lean().exec();
@@ -91,8 +92,8 @@ export async function resolveConfig(source, _id, key, activated, context) {
 export async function resolveGroupConfig(source, _id, name, activated, context) {
     const args = {};
 
-    if (_id) { args._id = _id; }
-    if (name) { args.name = name; }
+    if (_id) { args._id = new Types.ObjectId(_id); }
+    if (name) { args.name = formatInput(name, { allowSpace: true }); }
 
     let groups = await GroupConfig.find({ domain: source._id, ...args }).lean().exec();
     
@@ -118,14 +119,14 @@ export async function resolveDomain(_id, name, activated, context) {
     // When Admin
     if (context.admin) {
         if (name) {
-            args.name = name;
-            args.owner = context.admin._id;
+            args.name = formatInput(name, { allowSpace: true });
+            args.owner = new Types.ObjectId(context.admin._id);
         } else {
-            args._id = _id;
+            args._id = new Types.ObjectId(_id);
         }
     // When Component / GitOps
     } else if (context.domain) {
-        args._id = context.domain;
+        args._id = new Types.ObjectId(context.domain);
     }
     
     let domain = await Domain.findOne({ ...args }).lean().exec();


### PR DESCRIPTION
This pull request refactors several resolver functions in `src/aggregator/resolvers.js` to improve input validation and ensure proper data types when querying MongoDB. The main changes involve converting string IDs to `ObjectId`, formatting input fields, and enforcing enum values for certain arguments. These updates help prevent errors and ensure consistency across database queries.

**Input validation and transformation improvements:**

* All `_id` fields in resolver functions are now explicitly converted to `Types.ObjectId` before being used in MongoDB queries, reducing the risk of type-related errors. [[1]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL29-R32) [[2]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL68-R70) [[3]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL94-R96) [[4]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL121-R129)
* The `key` and `name` fields are now formatted using the `formatInput` helper to enforce consistent casing, underscores, and allowed spaces as appropriate for each resolver. [[1]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL68-R70) [[2]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL94-R96) [[3]](diffhunk://#diff-04237aaee30c558988215bd13eccd3998aad9f2c8006db9a61b8234828b5139dL121-R129)

**Enum enforcement:**

* The `strategy` and `operation` arguments in `resolveConfigStrategy` are now validated against the `StrategiesType` and `OperationsType` enums, ensuring only valid values are used in queries.

**Imports update:**

* Added imports for `Types`, `OperationsType`, `StrategiesType`, and `formatInput` to support the above changes.