### PR TITLE
chore: replacing Cache with PermissionCache, bump deps

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,10 +15,10 @@
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "express-basic-auth": "^1.2.1",
-        "express-rate-limit": "^8.5.0",
+        "express-rate-limit": "^8.5.1",
         "express-session": "^1.19.0",
         "express-validator": "^7.3.2",
-        "graphql": "^16.13.2",
+        "graphql": "^16.14.0",
         "graphql-http": "^1.22.4",
         "graphql-tag": "^2.12.6",
         "helmet": "^8.1.0",
@@ -40,7 +40,7 @@
         "jest-sonar-reporter": "^2.0.0",
         "node-notifier": "^10.0.1",
         "nodemon": "^3.1.14",
-        "sinon": "^21.1.2",
+        "sinon": "^22.0.0",
         "supertest": "^7.2.2"
       }
     },
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1510,9 +1510,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -1720,9 +1720,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2512,9 +2512,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {
@@ -2965,9 +2965,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3011,9 +3011,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "dev": true,
       "license": "ISC"
     },
@@ -3444,12 +3444,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3975,9 +3975,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -4203,9 +4203,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6723,16 +6723,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "21.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
-      "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+      "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.3.2",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@sinonjs/samsam": "^10.0.2",
-        "diff": "^8.0.4"
+        "diff": "^9.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "express-basic-auth": "^1.2.1",
-    "express-rate-limit": "^8.5.0",
+    "express-rate-limit": "^8.5.1",
     "express-session": "^1.19.0",
     "express-validator": "^7.3.2",
-    "graphql": "^16.13.2",
+    "graphql": "^16.14.0",
     "graphql-http": "^1.22.4",
     "graphql-tag": "^2.12.6",
     "helmet": "^8.1.0",
@@ -68,7 +68,7 @@
     "jest-sonar-reporter": "^2.0.0",
     "node-notifier": "^10.0.1",
     "nodemon": "^3.1.14",
-    "sinon": "^21.1.2",
+    "sinon": "^22.0.0",
     "supertest": "^7.2.2"
   },
   "repository": {

--- a/src/aggregator/permission-resolvers.js
+++ b/src/aggregator/permission-resolvers.js
@@ -2,7 +2,7 @@ import { verifyOwnership } from '../helpers/index.js';
 import { RouterTypes } from '../models/permission.js';
 import { getConfigs } from '../services/config.js';
 import { getGroupConfigs } from '../services/group-config.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 import Logger from '../helpers/logger.js';
 
 export async function resolvePermission(args, admin) {

--- a/src/helpers/permission-cache.js
+++ b/src/helpers/permission-cache.js
@@ -1,6 +1,6 @@
 import { ActionTypes, RouterTypes } from '../models/permission.js';
 
-class Cache {
+class PermissionCache {
     constructor() {
         this.cache = new Map();
     }
@@ -58,6 +58,6 @@ class Cache {
     }
 }
 
-const permissionCache = new Cache();
+const permissionCache = new PermissionCache();
 
 export { permissionCache };

--- a/src/routers/admin.js
+++ b/src/routers/admin.js
@@ -3,7 +3,7 @@ import { check } from 'express-validator';
 import { auth, authRefreshToken } from '../middleware/auth.js';
 import { validate, verifyInputUpdateParameters } from '../middleware/validators.js';
 import { formatInput, verifyOwnership } from '../helpers/index.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 import { responseException } from '../exceptions/index.js';
 import * as Services from '../services/admin.js';
 import { SwitcherKeys } from '../external/switcher-api-facade.js';

--- a/src/services/component.js
+++ b/src/services/component.js
@@ -2,7 +2,7 @@ import { checkComponent } from '../external/switcher-api-facade.js';
 import Component from '../models/component.js';
 import { ActionTypes, RouterTypes } from '../models/permission.js';
 import { formatInput, verifyOwnership } from '../helpers/index.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 import { response } from './common.js';
 
 export async function getComponentById(id) {

--- a/src/services/config-strategy.js
+++ b/src/services/config-strategy.js
@@ -2,7 +2,7 @@ import { response } from './common.js';
 import { ConfigStrategy } from '../models/config-strategy.js';
 import { ActionTypes, RouterTypes } from '../models/permission.js';
 import { verifyOwnership } from '../helpers/index.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 import { updateDomainVersion } from './domain.js';
 import { getConfigById } from './config.js';
 import { BadRequestError } from '../exceptions/index.js';

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -9,7 +9,7 @@ import { BadRequestError, NotFoundError } from '../exceptions/index.js';
 import { checkEnvironmentStatusChange } from '../middleware/validators.js';
 import { getComponentById, getComponents } from './component.js';
 import { resolveVerification } from './relay.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 
 async function verifyAddComponentInput(configId, admin) {
     const config = await getConfigById(configId);

--- a/src/services/domain.js
+++ b/src/services/domain.js
@@ -9,7 +9,7 @@ import GroupConfig from '../models/group-config.js';
 import History from '../models/history.js';
 import { ActionTypes, RouterTypes } from '../models/permission.js';
 import { formatInput, verifyOwnership, checkEnvironmentStatusRemoval } from '../helpers/index.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 import { response } from './common.js';
 import Logger from '../helpers/logger.js';
 import { BadRequestError } from '../exceptions/index.js';

--- a/src/services/environment.js
+++ b/src/services/environment.js
@@ -4,7 +4,7 @@ import { ConfigStrategy } from '../models/config-strategy.js';
 import { Environment, EnvType } from '../models/environment.js';
 import { ActionTypes, RouterTypes } from '../models/permission.js';
 import { formatInput, verifyOwnership } from '../helpers/index.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 import { response } from './common.js';
 import { getConfigs, removeConfigStatus } from './config.js';
 import { getDomainById, removeDomainStatus } from './domain.js';

--- a/src/services/group-config.js
+++ b/src/services/group-config.js
@@ -6,7 +6,7 @@ import { checkGroup } from '../external/switcher-api-facade.js';
 import { ActionTypes, RouterTypes } from '../models/permission.js';
 import { getDomainById, updateDomainVersion } from './domain.js';
 import { checkEnvironmentStatusChange } from '../middleware/validators.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 
 export async function getGroupConfigById(id, lean = false, populateAdmin = false) {
     let group = await GroupConfig.findById(id, null, { lean }).exec();

--- a/src/services/permission.js
+++ b/src/services/permission.js
@@ -3,7 +3,7 @@ import { ActionTypes, Permission, RouterTypes } from '../models/permission.js';
 import { verifyOwnership } from '../helpers/index.js';
 import { response } from './common.js';
 import { getTeam, getTeams, verifyRequestedTeam } from './team.js';
-import { permissionCache } from '../helpers/cache.js';
+import { permissionCache } from '../helpers/permission-cache.js';
 
 async function verifyRequestedTeamByPermission(permissionId, admin, action) {
     let team = await getTeam({ permissions: permissionId });

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -7,7 +7,7 @@ import app from '../src/app';
 import Admin from '../src/models/admin';
 import { Team } from '../src/models/team';
 import { EnvType } from '../src/models/environment';
-import { permissionCache } from '../src/helpers/cache';
+import { permissionCache } from '../src/helpers/permission-cache';
 import { ActionTypes, RouterTypes } from '../src/models/permission';
 import swaggerDocument from '../src/api-docs/swagger-document';
 import { 

--- a/tests/aggregator-api.test.js
+++ b/tests/aggregator-api.test.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 import sinon from 'sinon';
 import app from '../src/app';
 import { ActionTypes, Permission, RouterTypes } from '../src/models/permission';
-import { permissionCache } from '../src/helpers/cache';
+import { permissionCache } from '../src/helpers/permission-cache';
 import { Team } from '../src/models/team';
 import { EnvType } from '../src/models/environment';
 import Admin from '../src/models/admin';

--- a/tests/unit-test/permission-cache.test.js
+++ b/tests/unit-test/permission-cache.test.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { permissionCache } from '../../src/helpers/cache';
+import { permissionCache } from '../../src/helpers/permission-cache';
 import { EnvType } from '../../src/models/environment';
 import { ActionTypes, RouterTypes } from '../../src/models/permission';
 
@@ -16,7 +16,7 @@ describe('Test permissionCache', () => {
         permissionCache.cache.clear();
     });
 
-    it('UNIT_CACHE - Should set and get cache', () => {
+    it('UNIT_PERMISSION_CACHE - Should set and get cache', () => {
         const cacheKey = permissionCache.permissionKey(
             'adminId', 
             'domainId', 
@@ -31,7 +31,7 @@ describe('Test permissionCache', () => {
         expect(result).toEqual('value');
     });
 
-    it('UNIT_CACHE - Should reload cache', () => {
+    it('UNIT_PERMISSION_CACHE - Should reload cache', () => {
         const cacheKey = permissionCache.permissionKey(
             'adminId', 
             'domainId', 
@@ -46,7 +46,7 @@ describe('Test permissionCache', () => {
         expect(result).toBeUndefined();
     });
 
-    it('UNIT_CACHE - Should NOT reload cache', () => {
+    it('UNIT_PERMISSION_CACHE - Should NOT reload cache', () => {
         const cacheKey = permissionCache.permissionKey(
             'adminId', 
             'domainId', 
@@ -61,7 +61,7 @@ describe('Test permissionCache', () => {
         expect(result).toEqual('value');
     });
 
-    it('UNIT_CACHE - Should NOT reload cache - empty router/action', () => {
+    it('UNIT_PERMISSION_CACHE - Should NOT reload cache - empty router/action', () => {
         const cacheKey = permissionCache.permissionKey(
             'adminId', 
             'domainId', 
@@ -76,7 +76,7 @@ describe('Test permissionCache', () => {
         expect(result).toEqual('value');
     });
 
-    it('UNIT_CACHE - Should NOT get from cache - different environment', () => {
+    it('UNIT_PERMISSION_CACHE - Should NOT get from cache - different environment', () => {
         const cacheKey = permissionCache.permissionKey(
             'adminId', 
             'domainId', 


### PR DESCRIPTION
This pull request primarily updates dependencies and refactors the cache helper for permissions to improve clarity and maintainability. It upgrades several packages to their latest versions, and renames the generic `cache.js` to `permission-cache.js` throughout the codebase, updating all relevant imports and references. Additionally, test files and identifiers have been renamed to align with this change.

**Dependency Upgrades:**

* Upgraded key dependencies in `package.json` and `npm-shrinkwrap.json`, including `express-rate-limit` (8.5.1), `graphql` (16.14.0), `sinon` (22.0.0), and several others for improved security and compatibility. 

**Permission Cache Refactor:**

* Renamed `src/helpers/cache.js` to `src/helpers/permission-cache.js`, and updated all imports in service, resolver, and test files to use the new module name.

* Changed the exported class from `Cache` to `PermissionCache` in the new helper file for better specificity. 

**Testing Updates:**

* Renamed the test file `tests/unit-test/cache.test.js` to `tests/unit-test/permission-cache.test.js` and updated test identifiers to match the new naming convention.

These changes help clarify the purpose of the permission cache, improve code consistency, and keep dependencies up to date.